### PR TITLE
docs: prefer 'moonbit check' in README + drop not()

### DIFF
--- a/README.mbt.md
+++ b/README.mbt.md
@@ -15,7 +15,7 @@ A MoonBit library for manipulation of IP (IPv4/IPv6) and MAC address representat
 
 ## Usage
 
-```moonbit nocheck
+```moonbit check
 ///|
 test "readme_examples" {
   // IPv4 addresses
@@ -28,7 +28,7 @@ test "readme_examples" {
   // IPv4 CIDR prefixes
   let prefix = @ipaddr.ipv4_prefix(@ipaddr.ipv4(192, 168, 1, 0), 24)
   let contains = prefix.contains(addr)
-  if not(contains) {
+  if !contains {
     fail("Address should be contained in prefix")
   }
 


### PR DESCRIPTION
```moonbit nocheck``` → ```moonbit check``` so README examples actually type-check. One supporting fix: `not(contains)` → `!contains` ([E0020]).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbit-community/ipaddr/pull/5" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
